### PR TITLE
Fix ImportBevel for Blender 4.3

### DIFF
--- a/ldraw_mesh.py
+++ b/ldraw_mesh.py
@@ -24,6 +24,11 @@ def create_mesh(key, geometry_data, color_code, return_mesh=False):
 
         mesh.transform(matrices.rotation_matrix)
 
+        # Create the bevel_weight_edge attribute
+        if ImportOptions.bevel_edges:
+            if "bevel_weight_edge" not in mesh.attributes:
+                mesh.attributes.new(name="bevel_weight_edge", type='FLOAT', domain='EDGE')
+
     return mesh
 
 
@@ -173,7 +178,18 @@ def __process_mesh_sharp_edges(mesh, geometry_data):
     if ImportOptions.smooth_type_value() == "edge_split" or ImportOptions.use_freestyle_edges or ImportOptions.bevel_edges:
         edge_indices = __get_edge_indices(mesh.vertices, geometry_data)
 
-        for edge in mesh.edges:
+        # If we need bevel edges, get a reference to the attribute data
+        # so we can assign bevel weights by index.
+        bevel_attr_data = None
+        if ImportOptions.bevel_edges:
+            # The attribute should have been created in create_mesh
+            if "bevel_weight_edge" in mesh.attributes:
+                bevel_attr_data = mesh.attributes["bevel_weight_edge"].data
+
+        # we need i for indexing
+        # Original code was: for edge in mesh.edges:
+        # We'll use enumerate to index the edges for attribute assignment
+        for i, edge in enumerate(mesh.edges):
             v0 = edge.vertices[0]
             v1 = edge.vertices[1]
             if (v0, v1) in edge_indices:
@@ -181,8 +197,9 @@ def __process_mesh_sharp_edges(mesh, geometry_data):
                     edge.use_edge_sharp = True
                 if ImportOptions.use_freestyle_edges:
                     edge.use_freestyle_mark = True
-                if ImportOptions.bevel_edges:
-                    edge.bevel_weight = ImportOptions.bevel_weight
+                if ImportOptions.bevel_edges and bevel_attr_data is not None:
+                    # Instead of using edge.bevel_weight, we now assign the value to the attribute
+                    bevel_attr_data[i].value = ImportOptions.bevel_weight
 
 
 def __process_mesh(mesh):


### PR DESCRIPTION

Fixes the error you get when attempting to import an object with Bevel Edges enabled.

The error AttributeError: 'MeshEdge' object has no attribute 'bevel_weight' is caused due to the Blender 4.3 changes to the Python API for bevel edges not being a property anymore but instead an attribute that only gets created if the user manually creates bevel weights in the model's edges in edit mode, and because the property doesn't exist then the import fails. https://developer.blender.org/docs/release_notes/4.0/python_api/

This updated ldraw_mesh.py fixes the issue by adding a "bevel_weight_edge" attribute to the created objects, that way the add-on can use this attribute instead of the deprecated one.

And because this is an API change that means the script with this version for the addon is only compatible with Blender 4.3 forwards